### PR TITLE
Allow for alternat <template> position

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ module.exports = function vitePluginVuePugIndentFix() {
     name: 'vite-plugin-vue-pug-indent-fix',
     transform(src, id) {
       if(/\.(vue)/.test(id)) {
-        if(src.startsWith("<template")) { // Vue3 setup component
+        if(src.includes("<template")) { // Vue3 setup component
           const contentTemp = src.match(/<template(?:.+?)>(.*?)<\/template>/s)
           let content = contentTemp && contentTemp[1]
           const oldContent = content


### PR DESCRIPTION
During vite build (not during vite dev for some reason)  the use of "src.startsWith(..." in index.js causes an exception , if the vue file does not start with "<template" ( even an empty line is a problem).

This patch replaces  "src.startsWith(..."  with "src.includes(...", and then everthing works.